### PR TITLE
Fix references from qx.libraryPath -> qx.library

### DIFF
--- a/development/cli/commands.md
+++ b/development/cli/commands.md
@@ -54,7 +54,7 @@ with any name you likee, the `qx` command will look for the following special
 keys:
 
 `github.token` - this is the API token used when connecting to GitHub
-`qx.libraryPath` - this is the Qooxdoo library to use when compiling your
+`qx.library` - this is the Qooxdoo library to use when compiling your
 application
 
 ## Create a new project

--- a/development/cli/commands.md
+++ b/development/cli/commands.md
@@ -118,7 +118,7 @@ Options:
 
 The compiler relies on the information contained in `compile.json`.
 Documentation for the `compile.json` format is
-[here](../configuration/compile.md) .
+[here](../compiler/configuration/compile.md) .
 
 ## Lint
 
@@ -140,7 +140,7 @@ Options:
 ```
 
 Configuration is done in the `compile.json` file, see here
-[here](../configuration/compile.md) .
+[here](../compiler/configuration/compile.md) .
 
 If no special lint configuration is given in `compile.json` the configuration
 `@Qooxdoo/qx/browser` from
@@ -219,7 +219,7 @@ Options:
 Note that the `qx serve` command supports exactly the same options as
 `qx compile`, with the exception of `--watch` because that is always enabled;
 for more details of the options and the compilation process, please see
-[here](../configuration/compile.md)
+[here](../compiler/configuration/compile.md)
 
 ## Building for Production and Deployment
 

--- a/development/compiler/configuration/compile.md
+++ b/development/compiler/configuration/compile.md
@@ -350,7 +350,7 @@ key, for example:
 ```
 
 Unless you list it in the `libraries` key, the compiler will first check the
-`qx.libraryPath` setting (see `qx config set qx.libraryPath` ), and if not will
+`qx.library` setting (see `qx config set qx.library` ), and if not will
 look first in your `node_modules` directory and then it's own `node_modules`
 directory for the `@Qooxdoo/framework` npm module.
 


### PR DESCRIPTION
As just discovered, trying to set `qx.libraryPath` does nothing, the actual config setting is `qx.library`. This just updates the docs for the next person.