### PR TITLE
Add alias file for redirections

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,7 @@ one page, please clone
 [the documentation repository](https://github.com/qooxdoo/documentation) and do
 your edits. Before creating a PR with your changes, make sure to `npm install`
 and `npm test`. This will check your markdown and enforce certain style rules.
+
+If you move or rename pages, make sure to add a redirection
+in the [alias.js](/alias.js) file, so that internal links
+and especially external links to them are not broken.

--- a/alias.js
+++ b/alias.js
@@ -1,0 +1,10 @@
+/**
+ * For each page in the documentation that has been been renamed
+ * or moved to a new location, add an entry to the following map.
+ * @see https://docsify.js.org/#/configuration?id=alias
+ */
+window.docsify_alias = {
+  '/.*/_sidebar\.md': '/_sidebar.md',
+  '/test-[0-9]+': "/about.md",
+  "/test": "/about.md"
+};

--- a/index.html
+++ b/index.html
@@ -12,14 +12,13 @@
 </head>
 <body>
   <div id="app">Loading the qooxdoo documentation ...</div>
+  <script src="alias.js"></script>
   <script>
     window.$docsify = {
       markdown: {
         gfm: true, tables: true
       },
-      alias: {
-        '/.*/_sidebar.md': '/_sidebar.md',
-      },
+      alias: window.docsify_alias,
       name: '@qooxdoo/framework',
       repo: 'https://github.com/qooxdoo/qooxdoo',
       coverpage: true,


### PR DESCRIPTION
To avoid broken links when renaming or moving files in the documentation, the docsify alias configuration is moved to a separate file, which is easier to edit. We should enforce that this file be updated when files are renamed or moved. 