### PR TITLE
Fix typo where some repositories where under "Qooxdoo" namespace inst…

### DIFF
--- a/development/apidoc/README.md
+++ b/development/apidoc/README.md
@@ -130,7 +130,7 @@ If you haven't already, install the apiviewer package without making it a
 dependency of your application:
 
 ```bash
-npx qx pkg install --save=0 Qooxdoo/qxl.apiviewer
+npx qx pkg install --save=0 qooxdoo/qxl.apiviewer
 ```
 
 Then start the Qooxdoo application server...

--- a/development/compiler/README.md
+++ b/development/compiler/README.md
@@ -101,8 +101,8 @@ Here's an example where we add a couple of packages into your project, and then
 serve them up:
 
 ```javascript
-qx package install Qooxdoo/qxl.apiviewer
-qx package install Qooxdoo/qxl.widgetbrowser
+qx package install qooxdoo/qxl.apiviewer
+qx package install qooxdoo/qxl.widgetbrowser
 qx serve --show-startpage
 ```
 

--- a/development/compiler/configuration/Manifest.md
+++ b/development/compiler/configuration/Manifest.md
@@ -60,7 +60,7 @@ This is a sample file:
   "requires": {
     "@qooxdoo/framework": "^6.0.0-alpha",
     "@qooxdoo/compiler": "^0.2.40",
-    "Qooxdoo/contrib": "^0.1.1"
+    "qooxdoo/contrib": "^0.1.1"
   }
 }
 ```

--- a/development/testing/unit_testing.md
+++ b/development/testing/unit_testing.md
@@ -58,7 +58,7 @@ you!
 
 To run browser based test you have to
 
-- install testapper with `qx package install Qooxdoo/qxl.testtapper --save=0`
+- install testapper with `qx package install qooxdoo/qxl.testtapper --save=0`
 - prepare testapper application in your `compile.json` by adding your test
   namespace:
 
@@ -101,7 +101,7 @@ mock server responses.
 The unit tests can be run using the
 [TestTapper application](https://github.com/qooxdoo/qxl.testtapper/blob/master/README.md)
 , which you can easily install by executing
-`npx qx package install --save=0 Qooxdoo/qxl.testtapper`. (`--save=0` ensures
+`npx qx package install --save=0 qooxdoo/qxl.testtapper`. (`--save=0` ensures
 that this test runner is not registered as a permanent dependency of your
 application).
 

--- a/tutorial/twitter/tutorial-part-8.md
+++ b/tutorial/twitter/tutorial-part-8.md
@@ -86,7 +86,7 @@ application.
 
 ```console
 $ npx qx package update
-$ npx qx package install Qooxdoo/qxl.testtapper
+$ npx qx package install qooxdoo/qxl.testtapper
 ```
 
 Installing the `qxl.testtapper` package adds a new application to your


### PR DESCRIPTION
…ead of "qooxdoo" (capital letter)
